### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Based on [WordPress Advanced Administration Handbook](https://docs.google.com/do
 
 ### External linking
 
-- [External Linking Policy – "Commercial blogs"](https://make.wordpress.org/docs/2020/07/06/external-linking-policy-commercial-blogs/)
+- [External Linking Policy (Summary)](https://make.wordpress.org/docs/handbook/documentation-team-handbook/external-linking-policy/)
 
 ### Example domains
 


### PR DESCRIPTION
Change the link of External Linking Policy.

It should link to the summary because:
* It's easier for the readers to understand.
* The summary also reference the "commercial blogs (2020/07/06)" blog post in question.
* If in the future, new policy revises/overrides the "2020/07/06" post, the summary will get updated, but existing links to the "2020/07/06" post will not reflect the latest policy state (applicable/accurate).