### PR TITLE
New page: Security Display Errors

### DIFF
--- a/security/display-errors.md
+++ b/security/display-errors.md
@@ -1,0 +1,7 @@
+# Display Errors
+
+
+
+## Changelog
+
+- 2023-09-14: Setup.


### PR DESCRIPTION
This is a new page related to the [Core Ticket 52652](https://core.trac.wordpress.org/ticket/52652).

The idea is to explain why having debugging "on" always (or by default) is usually bad for security.

This file will be a subsection for Hardening WordPress