### PR TITLE
Update hardening.md wp-config.php .htaccess directives for Apache 2.4

### DIFF
--- a/security/hardening.md
+++ b/security/hardening.md
@@ -229,10 +229,9 @@ Note that `wp-config.php` can be stored ONE directory level above the WordPress 
 If you use a server with .htaccess, you can put this in that file (at the very top) to deny access to anyone surfing for it:
 
 ```
-<files wp-config.php>
-order allow,deny
-deny from all
-</files>
+<Files "wp-config.php">
+Require all denied
+</Files>
 ```
 
 ### Disable File Editing {#disable-file-editing}


### PR DESCRIPTION
This commit updates hardening.md guide, specifically .htaccess directives for wp-config.php file for Apache version 2.4. Using Order, Allow, Deny directives is deprecated. See: https://httpd.apache.org/docs/2.4/howto/access.html.