### PR TITLE
Fix broken link to Nginx handbook page

### DIFF
--- a/server/web-server.md
+++ b/server/web-server.md
@@ -8,7 +8,7 @@ TBD
 
 ## nginx
 
-See [Nginx](nginx.md).
+See [Nginx](https://developer.wordpress.org/advanced-administration/server/web-server/nginx/).
 
 ## Changelog
 


### PR DESCRIPTION
This solves an issue in this page https://developer.wordpress.org/advanced-administration/server/web-server/ where the link to Nginx is broken.