### PR TITLE
Fix capitalization of WordPress, periods in bullet items

### DIFF
--- a/server/wordpress-in-directory.md
+++ b/server/wordpress-in-directory.md
@@ -8,15 +8,15 @@ As of [Version 3.5](https://wordpress.org/documentation/wordpress-version/versio
 
 ## Moving a Root install to its own directory
 
-Let's say you've installed WordPress at `example.com`. Now you have two different methods to move wordpress installations into subdirectory:
+Let's say you've installed WordPress at `example.com`. Now you have two different methods to move WordPress installations into subdirectory:
 
 1. Without change of SITE-URL (remains `example.com`)
 2. With change in SITE-URL (it will redirect to `example.com/subdirectory`)
 
 ## Method I (Without URL change)
 
-1. After Installing the wordpress in root folder, move EVERYTHING from root folder into subdirectory.
-2. Create a `.htaccess` file in root folder, and put this content inside (just change `example.com` and `my_subdir`):
+1. After Installing WordPress in the root folder, move EVERYTHING from the root folder into subdirectory.
+2. Create a `.htaccess` file in the root folder, and put this content inside (just change `example.com` and `my_subdir`):
 
 ```
 <IfModule mod_rewrite.c>
@@ -39,17 +39,17 @@ That's all 🙂
 
 _(p.s. If you've already installed WP in subdirectory, some steps might be already done automatically)._
 
-1. Create the new location for the core WordPress files to be stored (we will use `/wordpress` in our examples). (On linux, use `mkdir wordpress` from your `www` directory. You'll probably want to use `chown apache:apache` on the `wordpress` directory you created.)
-2. Go to the [General](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings) Screen.
-3. In **WordPress address (URL):** set the address of your main WordPress core files. Example: https://example.com/wordpress
-4. In **Site address (URL):** set root directory's URL. Example: https://example.com
-5. Click **Save Changes**. (Do not worry about the errors that happen now! Continue reading)
+1. Create the new location for the core WordPress files to be stored—we will use `/wordpress` in our examples. On Linux, use `mkdir wordpress` from your `www` directory. You'll probably want to use `chown apache:apache` on the `wordpress` directory you created.
+2. Go to the [General](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings) screen.
+3. In **WordPress address (URL):** set the address of your main WordPress core files. Example: `https://example.com/wordpress`.
+4. In **Site address (URL):** set root directory's URL. Example: `https://example.com`.
+5. Click **Save Changes**. Do not worry about the errors that happen now! Continue reading.
 6. Now move your WordPress core files (from root directory) to the subdirectory.
 7. Copy (NOT MOVE!) the `index.php` and `.htaccess` files from the WordPress directory into the root directory of your site (Blog address). The `.htaccess` file is invisible, so you may have to set your FTP client to [show hidden files](https://developer.wordpress.org/advanced-administration/server/file-permissions/#Unhide_the_hidden_files). If you are not using [pretty permalinks](https://wordpress.org/documentation/article/using-permalinks/#using-pretty-permalinks), then you may not have a .`htaccess` file. _**If you are running WordPress on a Windows (IIS) server** and are using pretty permalinks, you'll have a `web.config` rather than a `.htaccess` file in your WordPress directory. For the `index.php` file the instructions remain the same, copy (don't move) the index.php file to your root directory. The `web.config` file, must be treated differently than the `.htaccess` file so you must MOVE (DON'T COPY) the `web.config` file to your root directory._
-8. Open your root directory's `index.php` file in a [text editor](https://wordpress.org/documentation/article/glossary#text-editor)
-9. Change the following and save the file. Change the line that says:`require dirname( __FILE__ ) . '/wp-blog-header.php';`to the following, using your directory name for the WordPress core files: `require dirname( __FILE__ ) . '/wordpress/wp-blog-header.php';`
-10. Login to the new location. It might now be https://example.com/wordpress/wp-admin/
-11. If you have set up [Permalinks](https://wordpress.org/documentation/article/using-permalinks/), go to the [Permalinks Screen](https://wordpress.org/documentation/article/administration-screens/#permalinks) and update your Permalink structure. WordPress will automatically update your `.htaccess` file if it has the appropriate file permissions. If WordPress can't write to your `.htaccess` file, it will display the new rewrite rules to you, which you should manually copy into your `.htaccess` file (in the same directory as the main `index.php` file.)
+8. Open your root directory's `index.php` file in a [text editor](https://wordpress.org/documentation/article/glossary#text-editor).
+9. Change the following and save the file. Change the line that says:`require dirname( __FILE__ ) . '/wp-blog-header.php';`to the following, using your directory name for the WordPress core files: `require dirname( __FILE__ ) . '/wordpress/wp-blog-header.php';`.
+10. Login to the new location. It might now be `https://example.com/wordpress/wp-admin/`.
+11. If you have set up [Permalinks](https://wordpress.org/documentation/article/using-permalinks/), go to the [Permalinks Screen](https://wordpress.org/documentation/article/administration-screens/#permalinks) and update your Permalink structure. WordPress will automatically update your `.htaccess` file if it has the appropriate file permissions. If WordPress can't write to your `.htaccess` file, it will display the new rewrite rules to you, which you should manually copy into your `.htaccess` file (in the same directory as the main `index.php` file).
 
 ### .htaccess modification
 


### PR DESCRIPTION
Added periods following the style guide:

https://make.wordpress.org/docs/style-guide/punctuation/periods/#bulleted-and-numbered-lists