### PR TITLE
Update services which now use HTTPS

### DIFF
--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -11,7 +11,7 @@ Most people use [Ping-o-Matic](https://pingomatic.com/) which, with just one "pi
 
 If you do not want the update services to be pinged, remove all the update service URIs listed under "Update Services" on the [Settings](https://wordpress.org/documentation/article/administration-screens/#settings-configuration-settings)->[Writing](https://wordpress.org/documentation/article/settings-writing-screen/) administration screen of your WordPress installation.
 
-![Screenshot of the Update Services screen.](https://wordpress.org/documentation/files/2018/10/update_service.png)
+![Screenshot of the Update Services screen.](https://wordpress.org/documentation/files/2025/06/update_service.png)
 
 Certain web hosts – particularly free ones – disable the PHP functions used to alert update services. If your web host prevents pings, you should stop WordPress from attempting to ping.
 

--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -18,8 +18,8 @@ Certain web hosts – particularly free ones – disable the PHP functions used 
 ## XML-RPC Ping Services
 
 ```
-http://rpc.pingomatic.com
-http://rpc.twingly.com
+https://rpc.pingomatic.com
+https://rpc.twingly.com
 http://www.blogdigger.com/RPC2
 http://ping.blo.gs/
 http://ping.feedburner.com

--- a/wordpress/update-services.md
+++ b/wordpress/update-services.md
@@ -20,11 +20,7 @@ Certain web hosts – particularly free ones – disable the PHP functions used 
 ```
 https://rpc.pingomatic.com
 https://rpc.twingly.com
-http://www.blogdigger.com/RPC2
 http://ping.blo.gs/
-http://ping.feedburner.com
-http://rpc.weblogs.com/RPC2
-http://www.pingmyblog.com
 ```
 
 ## Alternatives


### PR DESCRIPTION
See: https://github.com/WordPress/wordpress-develop/pull/9085

Closes https://github.com/WordPress/Documentation-Issue-Tracker/issues/1993