### PR TITLE
Update https.md

### DIFF
--- a/security/https.md
+++ b/security/https.md
@@ -63,7 +63,7 @@ For instance, with Nginx you need to have these lines:
 ```
 location / {
 	proxy_pass http://your_host_name:your_port;
-	proxy_set_header Host $host;
+	proxy_set_header Host $host:$server_port;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Host $server_name;


### PR DESCRIPTION
When using wordpress solution with docker compose (mysql, wordpress and nginx containers) and configuring nginx to receive https connection in a non default https port, it is necessary to include $server_port; in the Host header. If it is not there, some administration pages inside /wp-admin will load, but the root path and blog posts won't, resulting in ERR_TOO_MANY_REDIRECTS error.

The configuration was tested using the following docker images:

- wordpress:6.8.1-php8.4-apache
- nginx:alpine
- mysql:8.4