### PR TITLE
Fix typo in HTTPS documentation ($variabl → $variable)

### DIFF
--- a/security/https.md
+++ b/security/https.md
@@ -72,7 +72,7 @@ location / {
 }
 ```
 
-The variables like `$variabl`e are automatically managed by the reverse proxy.
+The variables like `$variable` are automatically managed by the reverse proxy.
 
 ### Further Information {#further-information}
 


### PR DESCRIPTION
This pull request fixes a minor typo in the *security/https.md* documentation.

* **Previous text:** `The variables like $variabl e are automatically managed by the reverse proxy.`
* **Corrected text:** `The variables like $variable are automatically managed by the reverse proxy.`

This change improves readability and accuracy in the HTTPS section of the WordPress Advanced Administration Handbook.