### PR TITLE
Clarify WP_CACHE, cache drop-ins, and performance constants

### DIFF
--- a/wordpress/wp-config.md
+++ b/wordpress/wp-config.md
@@ -299,6 +299,7 @@ define( 'WP_DEBUG_DISPLAY', false );
 @ini_set( 'display_errors', 0 );
 ```
 
+
 A refined version from Mike Little on the [Manchester WordPress User Group](https://groups.google.com/g/manchester-wordpress-user-group/c/tHJxMGhcnZs/m/dn-8yjYIq9wJ):
 
 ```
@@ -375,11 +376,79 @@ Note: this has to be put before wp-settings.php inclusion.
 
 ### Cache {#cache}
 
-The **WP_CACHE** setting, if true, includes the `wp-content/advanced-cache.php` script, when executing `wp-settings.php`.
+WordPress supports several different caching mechanisms. These systems are independent and are not all controlled by the same constant or subsystem.
 
-```
+#### `WP_CACHE`
+
+```php
 define( 'WP_CACHE', true );
 ```
+
+`WP_CACHE` does not enable caching by itself.
+
+When set to `true`, WordPress attempts to load the `wp-content/advanced-cache.php` drop-in early during bootstrap. This is commonly used by page caching plugins and some hosting platforms.
+
+If no `advanced-cache.php` file exists, defining `WP_CACHE` has little or no effect.
+
+Many caching plugins automatically add or manage this constant.
+
+#### Persistent object cache
+
+Persistent object caching uses an `object-cache.php` drop-in and is separate from `advanced-cache.php`.
+
+Examples include Redis and Memcached integrations.
+
+Persistent object caching may function even when `WP_CACHE` is not defined.
+
+#### Transients and persistent object caching
+
+The Transients API stores temporary data with an expiration time, but where that data is stored depends on the site's cache configuration.
+
+When a persistent object cache drop-in such as Redis or Memcached is active, transients can be stored in the external object cache. Without a persistent object cache, WordPress stores transient values in the database, typically in the `wp_options` table.
+
+This means transients should not be assumed to be memory-backed on all sites. Heavy transient usage on a site without persistent object caching can increase database reads and writes and contribute to options table growth.
+
+Transients set with an expiration time are not autoloaded by default; transients set without an expiration are autoloaded. This means heavy use of expiring transients adds rows to `wp_options` without adding to the autoload footprint loaded on every request.
+
+#### Cache layers
+
+Different cache layers serve different purposes:
+
+| Cache type | Typical implementation | Purpose |
+| --- | --- | --- |
+| Page cache | `advanced-cache.php` | Serve complete rendered pages |
+| Object cache | `object-cache.php` | Cache database/query/application objects |
+| Opcode cache | PHP OPcache | Cache compiled PHP bytecode |
+| Browser cache | HTTP headers/CDN | Cache assets in browsers |
+
+#### Common misconceptions
+
+- `WP_CACHE` does not automatically enable Redis or Memcached.
+- `WP_CACHE` does not enable browser caching.
+- `WP_CACHE` alone does not improve performance unless a caching drop-in is installed.
+- Persistent object cache and page cache are separate systems.
+- Transients are not always stored in memory; without persistent object caching, they are stored in the database.
+- Transient option rows in `wp_options` are not necessarily autoloaded; only transients set without an expiration are autoloaded.
+
+#### Related
+
+For implementation details, see:
+
+- `advanced-cache.php`
+- `object-cache.php`
+- `wp_start_object_cache()`
+- Drop-ins
+
+#### Legacy and specialized performance constants
+
+The following constants control specialized script and style loading, concatenation, and compression behavior:
+
+- `CONCATENATE_SCRIPTS`
+- `COMPRESS_SCRIPTS`
+- `COMPRESS_CSS`
+- `ENFORCE_GZIP`
+
+Most sites should not define these manually unless specifically troubleshooting performance or asset loading issues.
 
 ### Custom User and Usermeta Tables {#custom-user-and-usermeta-tables}
 


### PR DESCRIPTION
## Summary

Expands the `wp-config.php` cache documentation to: [1] explain that `WP_CACHE` loads the `advanced-cache.php` drop-in when present, [2] distinguish page caching from persistent object caching and other cache layers, [3] clarify how transients relate to persistent object caching, and [4] briefly note related script/CSS concatenation and compression constants.

## What and Why

Clarifies the `WP_CACHE` documentation in `wp-config.php`. The existing text correctly notes that `WP_CACHE` includes `wp-content/advanced-cache.php`, but it is brief and can be misread as meaning that `WP_CACHE` enables caching generally.

This update makes the scope of `WP_CACHE` more explicit: when set to `true`, WordPress attempts to load the `advanced-cache.php` drop-in if it exists. It does not enable persistent object caching, browser caching, PHP opcode caching, or other caching layers by itself.

The revised section also distinguishes `advanced-cache.php` from `object-cache.php`. Persistent object caching is a separate mechanism and may work independently of `WP_CACHE`.

It also clarifies that transients are not always memory-backed. When a persistent object cache drop-in such as Redis or Memcached is active, transients can be stored in the external object cache. Without persistent object caching, WordPress stores transient values in the database, typically in the `wp_options` table.

Finally, the patch briefly notes related script and CSS performance constants — `CONCATENATE_SCRIPTS`, `COMPRESS_SCRIPTS`, `COMPRESS_CSS`, and `ENFORCE_GZIP` — to make clear that these are specialized asset loading/compression controls, not general-purpose cache settings.

## Changes

- Clarify the purpose and limits of `WP_CACHE`.
- Document that `WP_CACHE` loads `advanced-cache.php` when present.
- Distinguish page caching from persistent object caching.
- Explain that `object-cache.php` is separate from `advanced-cache.php`.
- Clarify that transients may use a persistent object cache when available but otherwise fall back to database storage in `wp_options`.
- Add a table summarizing common cache layers.
- Add common misconceptions about `WP_CACHE`, persistent object caching, browser caching, and transients.
- Briefly note related script/CSS concatenation and compression constants.

## Related

- https://core.trac.wordpress.org/ticket/63017
- https://torstenlandsiedel.de/2025/04/24/fehler-im-wordpress-core-wo-keine-ki-helfen-kann/
- https://developer.wordpress.org/reference/functions/wp_start_object_cache/
- https://developer.wordpress.org/reference/classes/wp_object_cache/

## Notes for Reviewers

PR and commit text is a mix of me and my Claude+Codex editorial assistants. All of it is human-reviewed.