### PR TITLE
Improve FileZilla setup and troubleshooting guidance

### DIFF
--- a/upgrade/filezilla.md
+++ b/upgrade/filezilla.md
@@ -2,7 +2,7 @@
 
 [FileZilla](https://filezilla-project.org/) is an open-source file transfer client and server. Both the client and the server are available for Windows, Linux, and macOS. FileZilla supports **SFTP** and **FTPS** (encrypted), plus other protocols. If your host supports it, prefer **SFTP** over plain FTP.
 
-FileZilla may be used to manage your WordPress site by uploading and downloading files and images. This article will guide you through the process of installing and using the FileZilla FTP client to manage your WordPress site.
+FileZilla may be used to manage your WordPress site by uploading and downloading files and images. This article will guide you through the process of setting up and using the FileZilla client to manage your WordPress site.
 
 ![Screenshot of the FileZilla application](https://raw.githubusercontent.com/WordPress/Advanced-administration-handbook/main/assets/filezilla_1.gif)
 
@@ -10,9 +10,9 @@ For more information about FileZilla, view the [list of features](https://filezi
 
 ### Why would I want to download FileZilla?
 
-It's fast, stable, easy to use, and free. FTP is a standard way to upload or download files between your local system and your web server, and FileZilla is a solid client for everyday FTP needs.
+It's fast, stable, easy to use, and free. FileZilla can upload or download files between your local system and your web server. Whenever possible, use **SFTP** or **FTPS** instead of plain FTP so your connection is encrypted.
 
-## Setting Up the Options
+## Setting up the options
 
 You will need the following details from your host (for FTP, FTPS, or SFTP):
 
@@ -21,28 +21,30 @@ You will need the following details from your host (for FTP, FTPS, or SFTP):
 3. Your **username**
 4. Your **password** (or, for SFTP, sometimes an SSH key)
 
-If you do not already have an FTP account on your server, use your Control Panel or website administration tool to set one up — it will have all the information required. If in doubt, ask your host for directions or help regarding an FTP account for your use to access your webspace.
+If you do not already have an FTP, FTPS, or SFTP account on your server, use your hosting control panel or website administration tool to set one up. If in doubt, ask your host which protocol, host name, port, username, and authentication method you should use.
 
-Before connecting the FTP server, you should register it in the Site Manager. Once you register it, you just one click to connect to the same server.
+Before connecting to the server, register the connection in the Site Manager. Once you register it, you can connect to the same server again with one click.
 
-To register the FTP server, follow the below steps:
+To register the server, follow these steps:
 
-1. Click **File → Site Manager** from FileZilla main window.
-2. Click **New Site** then name the new connection to what you want (example: My blog server).
-3. Enter the host/server name in the **Host** box. This may be `ftp.example.com`, `example.com`, or a host-provided value. Check with your host if you do not know. Note: Do not put a `/` at the end unless specifically told to do so by your host.
-4. Choose the correct **Protocol** for your account (prefer **SFTP** when available). Leave **Port** blank unless your host provides a specific port. Common defaults are 22 (SFTP) and 21 (FTP).
-5. Select **Normal** from Logon Type box
-6. Enter the full username that you have been given in the User box. It may be just a username, or it may look like an email address (but it isn't one). For instance, it would look similar to `user` or `user@example.com`.
-7. Enter password. Remember that the password might be case-sensitive.
-8. Click OK.
+1. Click **File → Site Manager** from the FileZilla main window.
+2. Click **New Site**, then name the new connection. For example: My blog server.
+3. Enter the host/server name in the **Host** box. This may be `ftp.example.com`, `example.com`, or a host-provided value. Check with your host if you do not know. Do not add a `/` at the end unless your host specifically tells you to do so.
+4. Choose the correct **Protocol** for your account. Prefer **SFTP** when available. Leave **Port** blank unless your host provides a specific port. Common defaults are 22 for SFTP and 21 for FTP.
+5. Select the correct **Logon Type**. For password-based FTP or FTPS accounts, this is often **Normal**. For SFTP accounts, your host may ask you to use a password or an SSH key.
+6. Enter the full username that you have been given in the **User** box. It may be just a username, or it may look like an email address (but it isn't one). For instance, it would look similar to `user` or `user@example.com`.
+7. Enter the password if your account uses password authentication. Remember that the password might be case-sensitive.
+8. Click **OK**.
+
+Avoid saving passwords in FileZilla on shared or public computers. If you are using a shared computer, ask your host whether temporary credentials or key-based SFTP access are available.
 
 ![Screenshot of the FileZilla site manager window.](https://raw.githubusercontent.com/WordPress/Advanced-administration-handbook/main/assets/filezilla_3.gif)
 
 ## Connecting
 
-Go to the first icon in the toolbar of FileZilla's main window, "Open the Site Manager", click the down arrow, and select your FTP server from the dropdown list.
+Go to the first icon in the toolbar of FileZilla's main window, **Open the Site Manager**, click the down arrow, and select your server from the dropdown list.
 
-Alternatively, start the Site Manager from **File → Site Manager**, select your FTP server, and click 'Connect'.
+Alternatively, start the Site Manager from **File → Site Manager**, select your server, and click **Connect**.
 
 Following the appearance of a series of messages in the small window (Message Log), you should then see the list of the files on your server in the large window (Remote Directory Tree).
 
@@ -52,7 +54,7 @@ If you have a problem, then it's time to start troubleshooting!
 
 Look at the top area of the FileZilla main window and check the messages.
 
-1. If there was no attempt to connect, then the server/host name is wrong (or the protocol/port is incorrect). All it needs is one character to be incorrect and it will fail. Click the red X, break the connection, and click the Site Manager to check what you entered.
-2. If it says that the user does not exist or _Incorrect Login_ and so on, check the Site Manager setting and ensure that it reflects what your FTP account and password details provided by your host says, or use the web server administration interface provided to you by your host to re-check the existence of the FTP account. Check your password carefully. It is case-sensitive (capitals and small letters). You may want to ask your web host for some assistance, too.
-3. If it says _Could not retrieve directory listing_, you may need to change the Transfer Setting. From Site Manager, select your FTP Server and click the *Transfer Settings* tab. Select *Passive* from Transfer mode and click OK.
-
+1. If there was no attempt to connect, then the server/host name may be wrong, or the protocol or port may be incorrect. One incorrect character can cause the connection to fail. Click the red X, break the connection, and open the Site Manager to check what you entered.
+2. If it says that the user does not exist, _Incorrect Login_, or something similar, check the Site Manager settings against the account details provided by your host. Check your username, password, protocol, and port carefully. Passwords are case-sensitive.
+3. If it says _Could not retrieve directory listing_, you may need to change the transfer mode. From Site Manager, select your server and click the **Transfer Settings** tab. Select **Passive** from **Transfer mode** and click **OK**.
+4. If an SFTP connection fails but the host and username are correct, confirm with your host whether the account uses password authentication or an SSH key, and whether a custom port is required.

--- a/upgrade/filezilla.md
+++ b/upgrade/filezilla.md
@@ -12,7 +12,7 @@ For more information about FileZilla, view the [list of features](https://filezi
 
 It's fast, stable, easy to use, and free. FileZilla can upload or download files between your local system and your web server. Whenever possible, use **SFTP** or **FTPS** instead of plain FTP so your connection is encrypted.
 
-## Setting up the options
+## Setting Up the Options
 
 You will need the following details from your host (for FTP, FTPS, or SFTP):
 


### PR DESCRIPTION
## Summary

Updates the FileZilla documentation with clearer setup guidance, stronger SFTP/FTPS recommendations, and improved troubleshooting steps.

## Changes

- Prefer SFTP/FTPS over plain FTP where available.
- Clarify host, protocol, port, username, password, and SSH key guidance.
- Improve Site Manager setup instructions.
- Add a short note about avoiding saved passwords on shared computers.
- Improve troubleshooting for incorrect login details, passive mode, protocol/port issues, and SFTP authentication.

Fixes #131.