### PR TITLE
Improve must-use plugins documentation

### DIFF
--- a/plugins/mu-plugins.md
+++ b/plugins/mu-plugins.md
@@ -1,37 +1,79 @@
-# Must Use Plugins
+# Must-use plugins
 
-Must-use plugins (a.k.a. mu-plugins) are plugins installed in a special directory inside the content folder and which are automatically enabled on all sites in the installation. Must-use plugins do not show in the default list of plugins on the Plugins page of wp-admin (although they do appear in a special Must-Use section) and cannot be disabled except by removing the plugin file from the must-use directory, which is found in **wp-content/mu-plugins** by default. For web hosts, mu-plugins are commonly used to add support for host-specific features, especially those where their absence could break the site.
+Must-use plugins, also known as mu-plugins, are plugins installed in a special directory inside the content folder. They are automatically enabled on all sites in the installation.
+
+Must-use plugins do not show in the default list of plugins on the **Plugins** screen in wp-admin, although they do appear in a separate **Must-Use** section. They cannot be disabled from wp-admin. To disable a must-use plugin, remove the plugin file from the must-use plugins directory, which is **wp-content/mu-plugins** by default.
+
+Web hosts commonly use mu-plugins to add support for host-specific features, especially features where removing the plugin could break the site.
 
 To change the default directory manually, define `WPMU_PLUGIN_DIR` and `WPMU_PLUGIN_URL` in [wp-config.php](https://wordpress.org/documentation/article/editing-wp-config-php/).
 
+## When to use must-use plugins
+
+Must-use plugins are useful for code that should always run and should not be disabled accidentally from wp-admin.
+
+Common use cases include:
+
+* Host-specific integrations, such as caching, monitoring, or platform compatibility code.
+* Site-specific bootstrap code that must load before normal plugins.
+* Security, performance, or maintenance functionality that should remain active for the whole site.
+* Network-wide functionality on Multisite installations.
+
+## When not to use must-use plugins
+
+Must-use plugins are not a replacement for normal plugins in every situation. Avoid using the mu-plugins directory for plugins that:
+
+* Need activation or deactivation from wp-admin.
+* Depend on activation hooks, deactivation hooks, or uninstall hooks.
+* Need normal plugin update notifications in wp-admin.
+* Are intended to be distributed and managed like regular WordPress plugins.
+* Should be optional for site owners or administrators.
+
 ## Features
-* Always on, no need to enable via admin and users cannot disable by accident.
-* Can be enabled simply by uploading file to the mu-plugins directory, without having to log-in.
-* Loaded by PHP, in alphabetical order, before normal plugins, meaning API hooks added in an mu-plugin apply to all other plugins even if they run hooked-functions in the global namespace.
+
+* Always on, with no need to enable them in wp-admin.
+* Cannot be disabled by users by accident.
+* Can be enabled by uploading a PHP file to the mu-plugins directory.
+* Loaded by PHP in alphabetical order before normal plugins. This means hooks added in an mu-plugin can apply to normal plugins, even if those normal plugins run hooked functions in the global namespace.
 
 ## Caveats
+
 Despite its suitability for many special cases, the mu-plugins system is not always ideal and has several downsides that make it inappropriate in certain circumstances. Below are several important caveats to keep in mind:
 
-* Plugins in the must-use directory will not appear in the update notifications nor show their update status on the plugins page, so you are responsible for learning about and performing updates on your own.
-* Activation hooks are not executed in plugins added to the must-use plugins folder. These hooks are used by many plugins to run installation code that sets up the plugin initially and/or uninstall code that cleans up when the plugin is deleted. Plugins depending on these hooks may not function in the mu-plugins folder, and as such all plugins should be carefully tested specifically in the mu-plugins directory before being deployed to a live site.
-* WordPress only looks for PHP files right inside the mu-plugins directory, and (unlike for normal plugins) not for files in subdirectories. You may want to create a proxy PHP loader file inside the mu-plugins directory:
+* Plugins in the must-use directory will not appear in update notifications or show their update status on the plugins screen, so you are responsible for learning about and performing updates yourself.
+* Activation hooks are not executed for plugins added to the must-use plugins folder. These hooks are used by many plugins to run setup code when the plugin is activated, or cleanup code when the plugin is deleted. Plugins that depend on these hooks may not function correctly in the mu-plugins folder. Test plugins carefully in the mu-plugins directory before deploying them to a live site.
+* WordPress only looks for PHP files directly inside the mu-plugins directory. Unlike normal plugins, files in subdirectories are not included automatically. You may want to create a proxy PHP loader file inside the mu-plugins directory:
 
+```text
+wp-content/
+  mu-plugins/
+    load.php
+    my-plugin/
+      my-plugin.php
 ```
+
+```php
 <?php // mu-plugins/load.php
-require WPMU_PLUGIN_DIR.'/my-plugin/my-plugin.php';
+require WPMU_PLUGIN_DIR . '/my-plugin/my-plugin.php';
 ```
 
-## History and Naming
+## Maintenance and security
 
-The _mu-plugins_ directory was originally implemented by WPMU (Multi-User) to offer site admins an easy way to activate plugins by default on all blogs in the farm. There was a need for this feature because at the time the multi-user-specific code did not offer ways of achieving this effect using the site admin section (today the renamed “Multisite WordPress” has features to manage plugins from inside the admin).
+Because must-use plugins always load, keep them small, reviewed, and documented. A broken mu-plugin can affect the whole site, and a compromised mu-plugin can be harder to notice than a normal plugin because it cannot be disabled from the main plugins list.
 
-The code handling /mu-plugins/ was merged into the main WordPress code on 03/07/09 with [this changeset](https://core.trac.wordpress.org/changeset/10737) a full 10 months before the wpmu codebase was initially merged, and all WP sites could take advantage of autoloaded plugins, whether they had MU/Multisite enabled or not. The feature is useful for all types of WP installations depending on circumstances, so this makes sense.
+Keep a record of why each mu-plugin exists, who maintains it, and how it should be updated. If a host or agency adds mu-plugins to a site, site owners should know that those files exist and that they may affect site behavior.
 
-In this process the name “mu plugins” became a misnomer because it did not apply exclusively to multisite installs and because “MU” was not even being used anymore to refer to WP installations with multiple blogs. Despite this, the name was kept and **re-interpreted to mean “must-use plugins”**, i.e. these are plugins that must always be used, thus they are autoloaded on all sites regardless of the settings in the Plugins pane of wp-admin.
+## History and naming
 
-Thus “Must-Use” is effectively a [Backronym](https://en.wikipedia.org/wiki/Backronym), like [PHP](https://wordpress.org/documentation/article/wordpress-glossary/#PHP) (which originally meant “Personal Home Page” but was later re-interpreted as meaning “PHP Hypertext Preprocessor”, which is also a [Recursive Acronym](https://en.wikipedia.org/wiki/Recursive_acronym)).
+The _mu-plugins_ directory was originally implemented by WPMU (Multi-User) to offer site admins an easy way to activate plugins by default on all blogs in the network. This was needed because, at the time, the multi-user-specific code did not offer ways to manage this from the site admin section. Today, Multisite includes features to manage plugins from inside the admin.
 
-## Source Code
-* `get_mu_plugins()` is located in [wp-admin/includes/plugin.php](https://core.trac.wordpress.org/browser/tags/4.5.3/src/wp-admin/includes/plugin.php#L0).
-* `wp_get_mu_plugins()` is located in [wp-includes/load.php](https://core.trac.wordpress.org/browser/tags/4.5.3/src/wp-includes/load.php#L0).
+The code handling `/mu-plugins/` was merged into the main WordPress code on March 7, 2009 with [this changeset](https://core.trac.wordpress.org/changeset/10737), before the WPMU codebase was initially merged. This made autoloaded plugins available to all WordPress sites, whether or not Multisite was enabled.
 
+In this process, the name "mu plugins" became a misnomer because it no longer applied exclusively to multisite installations. Despite this, the name was kept and reinterpreted to mean "must-use plugins". These are plugins that must always be used, so they are autoloaded regardless of the settings in the **Plugins** screen of wp-admin.
+
+Thus, "must-use" is effectively a [backronym](https://en.wikipedia.org/wiki/Backronym).
+
+## Source code
+
+* [`get_mu_plugins()`](https://developer.wordpress.org/reference/functions/get_mu_plugins/) checks the mu-plugins directory and retrieves all mu-plugin files with plugin data.
+* [`wp_get_mu_plugins()`](https://developer.wordpress.org/reference/functions/wp_get_mu_plugins/) retrieves an array of must-use plugin files.

--- a/plugins/mu-plugins.md
+++ b/plugins/mu-plugins.md
@@ -8,7 +8,7 @@ Web hosts commonly use mu-plugins to add support for host-specific features, esp
 
 To change the default directory manually, define `WPMU_PLUGIN_DIR` and `WPMU_PLUGIN_URL` in [wp-config.php](https://wordpress.org/documentation/article/editing-wp-config-php/).
 
-## When to use must-use plugins
+## When to Use Must-use Plugins
 
 Must-use plugins are useful for code that should always run and should not be disabled accidentally from wp-admin.
 
@@ -19,7 +19,7 @@ Common use cases include:
 * Security, performance, or maintenance functionality that should remain active for the whole site.
 * Network-wide functionality on Multisite installations.
 
-## When not to use must-use plugins
+## When Not to Use Must-use Plugins
 
 Must-use plugins are not a replacement for normal plugins in every situation. Avoid using the mu-plugins directory for plugins that:
 
@@ -57,23 +57,25 @@ wp-content/
 require WPMU_PLUGIN_DIR . '/my-plugin/my-plugin.php';
 ```
 
-## Maintenance and security
+## Maintenance and Security
 
 Because must-use plugins always load, keep them small, reviewed, and documented. A broken mu-plugin can affect the whole site, and a compromised mu-plugin can be harder to notice than a normal plugin because it cannot be disabled from the main plugins list.
 
 Keep a record of why each mu-plugin exists, who maintains it, and how it should be updated. If a host or agency adds mu-plugins to a site, site owners should know that those files exist and that they may affect site behavior.
 
-## History and naming
+## History and Naming
 
-The _mu-plugins_ directory was originally implemented by WPMU (Multi-User) to offer site admins an easy way to activate plugins by default on all blogs in the network. This was needed because, at the time, the multi-user-specific code did not offer ways to manage this from the site admin section. Today, Multisite includes features to manage plugins from inside the admin.
+The _mu-plugins_ directory was originally implemented by WPMU, or WordPress MultiUser, to offer site admins an easy way to activate plugins by default on all blogs in the network. This was needed because, at the time, the multi-user-specific code did not offer ways to manage this from the site admin section.
+
+WordPress MultiUser was later merged into WordPress core, and the feature is now known as Multisite. Today, Multisite includes features to manage plugins from inside the admin.
 
 The code handling `/mu-plugins/` was merged into the main WordPress code on March 7, 2009 with [this changeset](https://core.trac.wordpress.org/changeset/10737), before the WPMU codebase was initially merged. This made autoloaded plugins available to all WordPress sites, whether or not Multisite was enabled.
 
-In this process, the name "mu plugins" became a misnomer because it no longer applied exclusively to multisite installations. Despite this, the name was kept and reinterpreted to mean "must-use plugins". These are plugins that must always be used, so they are autoloaded regardless of the settings in the **Plugins** screen of wp-admin.
+In this process, the name "mu plugins" became a misnomer because it no longer applied exclusively to Multisite installations. Despite this, the name was kept and reinterpreted to mean "must-use plugins". These are plugins that must always be used, so they are autoloaded regardless of the settings in the **Plugins** screen of wp-admin.
 
 Thus, "must-use" is effectively a [backronym](https://en.wikipedia.org/wiki/Backronym).
 
-## Source code
+## Source Code
 
 * [`get_mu_plugins()`](https://developer.wordpress.org/reference/functions/get_mu_plugins/) checks the mu-plugins directory and retrieves all mu-plugin files with plugin data.
 * [`wp_get_mu_plugins()`](https://developer.wordpress.org/reference/functions/wp_get_mu_plugins/) retrieves an array of must-use plugin files.

--- a/plugins/mu-plugins.md
+++ b/plugins/mu-plugins.md
@@ -1,4 +1,4 @@
-# Must-use plugins
+# Must-Use Plugins
 
 Must-use plugins, also known as mu-plugins, are plugins installed in a special directory inside the content folder. They are automatically enabled on all sites in the installation.
 
@@ -8,7 +8,7 @@ Web hosts commonly use mu-plugins to add support for host-specific features, esp
 
 To change the default directory manually, define `WPMU_PLUGIN_DIR` and `WPMU_PLUGIN_URL` in [wp-config.php](https://wordpress.org/documentation/article/editing-wp-config-php/).
 
-## When to Use Must-use Plugins
+## When to Use Must-Use Plugins
 
 Must-use plugins are useful for code that should always run and should not be disabled accidentally from wp-admin.
 
@@ -19,7 +19,7 @@ Common use cases include:
 * Security, performance, or maintenance functionality that should remain active for the whole site.
 * Network-wide functionality on Multisite installations.
 
-## When Not to Use Must-use Plugins
+## When Not to Use Must-Use Plugins
 
 Must-use plugins are not a replacement for normal plugins in every situation. Avoid using the mu-plugins directory for plugins that:
 


### PR DESCRIPTION
## Summary

Updates the Must-use plugins documentation with clearer guidance, practical use cases, caveats, and current source references.

## Changes

- Clarifies what must-use plugins are and how they behave in wp-admin.
- Adds guidance for when to use and when not to use must-use plugins.
- Improves the features and caveats sections.
- Adds a directory structure example and improves the proxy loader example.
- Adds maintenance and security guidance.
- Cleans up the history section.
- Replaces old WordPress 4.5.3 Trac source links with current Code Reference links.

Fixes #146.