### PR TITLE
Add PHPUnit and Xdebug to debugging docs

### DIFF
--- a/debug/debug-wordpress.md
+++ b/debug/debug-wordpress.md
@@ -146,3 +146,12 @@ There are many [debugging plugins](https://wordpress.org/plugins/search/debug/) 
 
 For example, [Debug Bar](https://wordpress.org/plugins/debug-bar/) adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information. When WP_DEBUG is enabled, it also tracks PHP Warnings and Notices to make them easier to find.
 
+## Automated tests and step debugging
+
+Logs and debugging plugins are useful for finding runtime errors, but some problems are easier to investigate with automated tests or a step debugger.
+
+[PHPUnit](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/) is used for automated PHP tests in WordPress development. Tests can help confirm that code behaves as expected and can prevent the same bug from returning later. For plugin projects, [WP-CLI can scaffold plugin test files](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/).
+
+[Xdebug](https://xdebug.org/docs/step_debug) is a PHP extension that can be used for step debugging with a compatible editor or IDE. It lets you pause code while it runs, inspect variables, and follow the call stack. This can be helpful when a log message does not show enough context to explain a problem.
+
+Use these tools in a local development or staging environment, not directly on a production site.

--- a/debug/debug-wordpress.md
+++ b/debug/debug-wordpress.md
@@ -146,7 +146,7 @@ There are many [debugging plugins](https://wordpress.org/plugins/search/debug/) 
 
 For example, [Debug Bar](https://wordpress.org/plugins/debug-bar/) adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information. When WP_DEBUG is enabled, it also tracks PHP Warnings and Notices to make them easier to find.
 
-## Automated tests and step debugging
+## Automated Tests and Step Debugging
 
 Logs and debugging plugins are useful for finding runtime errors, but some problems are easier to investigate with automated tests or a step debugger.
 

--- a/debug/index.md
+++ b/debug/index.md
@@ -8,6 +8,12 @@ In this part of the Advanced Administration Handbook, we will address various as
 
 When it comes to [debugging a WordPress site](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/), there are various methods and techniques to use, including turning on debugging in the WordPress configuration file, using error logs and the use of debugging plugins. These techniques can help identify and resolve various types of errors, such as PHP errors and database errors.
 
+## Testing and step debugging
+
+Automated tests and step debugging are useful when you need to investigate problems in code instead of only reading log output. [PHPUnit](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/) is used for automated PHP tests in WordPress development, and [WP-CLI can scaffold plugin test files](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) for plugin projects.
+
+[Xdebug](https://xdebug.org/docs/step_debug) can be used with a compatible editor or IDE to step through PHP code, inspect variables, and follow the call stack while a request is running.
+
 ## JavaScript Debugging
 
 [JavaScript debugging](https://developer.wordpress.org/advanced-administration/debug/debug-javascript/) is essential for ensuring that the site's front-end interactions and user experience are functioning correctly. Using browser dev tools to inspect the source code and diagnose issues with JavaScript along with a few more tips are provided in this section.
@@ -19,4 +25,3 @@ When it comes to [debugging a WordPress site](https://developer.wordpress.org/ad
 ## Test-driving
 
 [Test-driving](https://developer.wordpress.org/advanced-administration/debug/test-driving/) refers to the process of testing a website before making it live. This process allows developers to identify and resolve any issues or bugs before the site is made available to the public. Test-driving is typically performed in a sandbox environment. Creating a sandbox environment is covered in this section.
-

--- a/debug/index.md
+++ b/debug/index.md
@@ -8,7 +8,7 @@ In this part of the Advanced Administration Handbook, we will address various as
 
 When it comes to [debugging a WordPress site](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/), there are various methods and techniques to use, including turning on debugging in the WordPress configuration file, using error logs and the use of debugging plugins. These techniques can help identify and resolve various types of errors, such as PHP errors and database errors.
 
-## Testing and step debugging
+## Testing and Step Debugging
 
 Automated tests and step debugging are useful when you need to investigate problems in code instead of only reading log output. [PHPUnit](https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/) is used for automated PHP tests in WordPress development, and [WP-CLI can scaffold plugin test files](https://developer.wordpress.org/cli/commands/scaffold/plugin-tests/) for plugin projects.
 


### PR DESCRIPTION
## Summary

Adds PHPUnit and Xdebug references to the Debugging WordPress documentation.

## Changes

- Adds a testing and step debugging section to the Debugging overview.
- Mentions PHPUnit for automated PHP tests in WordPress development.
- Links to WP-CLI plugin test scaffolding for plugin projects.
- Adds Xdebug guidance for step debugging, variable inspection, and call stack inspection.
- Notes that these tools should be used in local or staging environments, not production.

Fixes #184.