### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported scope
+
+The WordPress Advanced Administration Handbook is a documentation repository. It does not ship WordPress core, plugins, themes, hosting software, or server packages.
+
+This policy covers security-sensitive issues in this repository's documentation and GitHub configuration. It does not define support for WordPress software versions, hosting stacks, plugins, themes, server packages, or hosting platforms.
+
+## Reporting vulnerabilities
+
+For WordPress core, plugins, themes, WordPress.org, or the wider WordPress ecosystem, follow the official [WordPress security reporting guidance](https://wordpress.org/about/security/). WordPress core vulnerabilities should be reported through the [WordPress HackerOne program](https://hackerone.com/wordpress).
+
+Do not report exploitable security vulnerabilities in public GitHub issues or pull requests.
+
+If the vulnerability is in a hosting platform, server package, or other third-party project, report it to that project or vendor through their security reporting process.
+
+## Documentation issues
+
+If you find an insecure, outdated, or unclear recommendation in the Advanced Administration Handbook documentation, open a public issue in this repository:
+
+https://github.com/WordPress/Advanced-administration-handbook/issues
+
+Include the affected page, the specific recommendation, and any safer source or replacement guidance you are suggesting. Do not include exploit details or private vulnerability information in public issues.


### PR DESCRIPTION
Fixes #505.

Ports the security policy the Hosting Team merged in WordPress/hosting-handbook#410, adapted for this repository. Only three lines differ from the accepted text: the handbook name in two places and the issues URL.

Placed in .github/ so it stays out of the published handbook content while GitHub still surfaces it on the repository's Security tab and in vulnerability report flows.